### PR TITLE
add newline to welcome middleware

### DIFF
--- a/server.go
+++ b/server.go
@@ -18,7 +18,7 @@ type Middleware func(http.ResponseWriter, *http.Request, *Context) error
 
 func NewWelcomeMiddleware(appName, version string) Middleware {
 	return func(res http.ResponseWriter, rep *http.Request, ctx *Context) error {
-		return ctx.Response.PlainText(fmt.Sprintf("This is %s version %s", appName, version), http.StatusOK)
+		return ctx.Response.PlainText(fmt.Sprintf("This is %s version %s\n", appName, version), http.StatusOK)
 	}
 }
 


### PR DESCRIPTION
I don't want the following to happen:

``` bash
$ curl localhost:8080
This is xxx version 0.1.0 $
```

Adding a newline prevents fragging my terminal.
