### PR TITLE
Added CleanupHandler to avoid gorilla context memory leaks

### DIFF
--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
 	"github.com/juju/errgo"
 
@@ -122,6 +123,9 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux, prefix string) {
 			handler,
 		)
 	}
+
+	// Always cleanup gorilla context request variables
+	handler = context.ClearHandler(handler)
 
 	// http.mux handlers need a trailing slash while gorilla's mux does not need one
 	// because they have different matching algorithms.


### PR DESCRIPTION
See important note in http://www.gorillatoolkit.org/pkg/sessions

"Important Note: If you aren't using gorilla/mux, you need to wrap your handlers with context.ClearHandler as or else you will leak memory! An easy way to do this is to wrap the top-level mux when calling http.ListenAndServe:"